### PR TITLE
Add a simple allocation error handler gated behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,6 @@ xtensa-lx             = { version = "0.7.0",  features = ["esp32s2"] }
 [target.xtensa-esp32s3-none-elf.dependencies]
 linked_list_allocator = "0.9.1"
 xtensa-lx             = { version = "0.7.0",  features = ["esp32s3"] }
+
+[features]
+oom-handler = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //! `nightly` release channel.
 
 #![no_std]
+#![cfg_attr(feature = "oom-handler", feature(alloc_error_handler))]
 
 use core::{
     alloc::{GlobalAlloc, Layout},
@@ -24,6 +25,12 @@ use linked_list_allocator::Heap;
 use riscv::interrupt;
 #[cfg(target_arch = "xtensa")]
 use xtensa_lx::interrupt;
+
+#[cfg(feature = "oom-handler")]
+#[alloc_error_handler]
+fn oom(_: core::alloc::Layout) -> ! {
+    panic!("Allocation failed, out of memory");
+}
 
 pub struct EspHeap {
     heap: Mutex<RefCell<Heap>>,


### PR DESCRIPTION
Rather than needing to define this in every binary which depends on this package, we can just provide a simple error handler.