### PR TITLE
Update the `linked_list_allocator` dependency to the newest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,19 @@ default-target = "riscv32imc-unknown-none-elf"
 bare-metal = "1.0.0"
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-linked_list_allocator = { version = "0.9.1", default-features = false, features = ["const_mut_refs"] }
+linked_list_allocator = { version = "0.10.1", default-features = false, features = ["const_mut_refs"] }
 riscv                 = "0.8.0"
 
 [target.xtensa-esp32-none-elf.dependencies]
-linked_list_allocator = "0.9.1"
+linked_list_allocator = "0.10.1"
 xtensa-lx             = { version = "0.7.0",  features = ["esp32"] }
 
 [target.xtensa-esp32s2-none-elf.dependencies]
-linked_list_allocator = { version = "0.9.1", default-features = false, features = ["const_mut_refs"] }
+linked_list_allocator = { version = "0.10.1", default-features = false, features = ["const_mut_refs"] }
 xtensa-lx             = { version = "0.7.0",  features = ["esp32s2"] }
 
 [target.xtensa-esp32s3-none-elf.dependencies]
-linked_list_allocator = "0.9.1"
+linked_list_allocator = "0.10.1"
 xtensa-lx             = { version = "0.7.0",  features = ["esp32s3"] }
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ impl EspHeap {
     /// This function must be called BEFORE you run any code that makes use of
     /// the allocator.
     ///
-    /// `start_addr` is the address where the heap will be located.
+    /// `heap_bottom` is a pointer to the location of the bottom of the heap.
     ///
     /// `size` is the size of the heap in bytes.
     ///
@@ -71,8 +71,8 @@ impl EspHeap {
     ///
     /// - This function must be called exactly ONCE.
     /// - `size > 0`
-    pub unsafe fn init(&self, start_addr: usize, size: usize) {
-        interrupt::free(|cs| self.heap.borrow(*cs).borrow_mut().init(start_addr, size));
+    pub unsafe fn init(&self, heap_bottom: *mut u8, size: usize) {
+        interrupt::free(|cs| self.heap.borrow(*cs).borrow_mut().init(heap_bottom, size));
     }
 
     /// Returns an estimate of the amount of bytes in use.


### PR DESCRIPTION
The only change for us is that `init` now takes a pointer to the bottom of the heap rather than the address.