### PR TITLE
Swap out `bare_metal` and use `critical_section` instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,23 +25,8 @@ categories = [
 default-target = "riscv32imc-unknown-none-elf"
 
 [dependencies]
-bare-metal = "1.0.0"
-
-[target.'cfg(target_arch = "riscv32")'.dependencies]
-linked_list_allocator = { version = "0.10.1", default-features = false, features = ["const_mut_refs"] }
-riscv                 = "0.8.0"
-
-[target.xtensa-esp32-none-elf.dependencies]
-linked_list_allocator = "0.10.1"
-xtensa-lx             = { version = "0.7.0",  features = ["esp32"] }
-
-[target.xtensa-esp32s2-none-elf.dependencies]
-linked_list_allocator = { version = "0.10.1", default-features = false, features = ["const_mut_refs"] }
-xtensa-lx             = { version = "0.7.0",  features = ["esp32s2"] }
-
-[target.xtensa-esp32s3-none-elf.dependencies]
-linked_list_allocator = "0.10.1"
-xtensa-lx             = { version = "0.7.0",  features = ["esp32s3"] }
+critical-section      = "1.1.0"
+linked_list_allocator = { version = "0.10.3", default-features = false, features = ["const_mut_refs"] }
 
 [features]
 # Provides a basic `#[alloc_error_handler]` which simply panics when an

--- a/README.md
+++ b/README.md
@@ -9,23 +9,7 @@ Currently supports:
 - ESP32-S2
 - ESP32-S3
 
-**NOTE:** using this as your global allocator requires using Rust's
-`nightly` release channel.
-
-## Build Notes
-
-In order to build this crate a valid target must be specified:
-
-| Architecture |                                       Targets                                       |
-| :----------: | :---------------------------------------------------------------------------------: |
-|    RISC-V    |                            `riscv32imc-unknown-none-elf`                            |
-|    Xtensa    | `xtensa-esp32-none-elf`<br/>`xtensa-esp32s2-none-elf`<br/>`xtensa-esp32s3-none-elf` |
-
-For example:
-
-```bash
-$ cargo build --target=riscv32imc-unknown-none-elf
-```
+**NOTE:** using this as your global allocator requires using Rust's `nightly` release channel.
 
 ## License
 


### PR DESCRIPTION
Pretty straight-forward changes, simplifies our manifest quite a bit. Should move us a bit closer to being finished with #1. The `use_spin` feature of `linked_list_allocator` is now disabled for all chips.