### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,18 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@v1
         with:
-          profile: minimal
           target: riscv32imc-unknown-none-elf
           toolchain: nightly
           components: rust-src
-          default: true
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -Zbuild-std=core --target=riscv32imc-unknown-none-elf
+      - run: cargo check -Zbuild-std=core --target=riscv32imc-unknown-none-elf
 
   check-xtensa:
     name: Check Xtensa
@@ -44,7 +39,4 @@ jobs:
           default: true
           ldproxy: false
       - uses: Swatinem/rust-cache@v2
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: -Zbuild-std=core --target=xtensa-${{ matrix.chip }}-none-elf
+      - run: cargo check -Zbuild-std=core --target=xtensa-${{ matrix.chip }}-none-elf


### PR DESCRIPTION
- Replace `actions-rs/toolchain` by `dtolnay/rust-toolchain`
- Avoid using `actions-rs/cargo`