### PR TITLE
Remove the `oom-handler` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,13 +28,3 @@ default-target = "riscv32imc-unknown-none-elf"
 [dependencies]
 critical-section      = "1.1.1"
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
-
-[features]
-# Provides a basic `#[alloc_error_handler]` which simply panics when an
-# allocation fails. If this feature is NOT enabled, which it is not by
-# default, then a handler needs to be defined in any binary depending on
-# this package.
-# As of Rust 1.68 the `default_alloc_error_handler` feature is enabled by
-# default, which will cause the compiler to automatically generate a handler
-# which panics when out of memory.
-oom-handler = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,10 @@
 //! A simple `no_std` heap allocator for RISC-V and Xtensa processors from
-//! Espressif.
-//!
-//! A simple `no_std` heap allocator for RISC-V and Xtensa processors from
 //! Espressif. Supports all currently available ESP32 devices.
 //!
 //! **NOTE:** using this as your global allocator requires using Rust 1.68 or
 //! greater, or the `nightly` release channel.
 
 #![no_std]
-#![cfg_attr(feature = "oom-handler", feature(alloc_error_handler))]
 
 use core::{
     alloc::{GlobalAlloc, Layout},
@@ -18,12 +14,6 @@ use core::{
 
 use critical_section::Mutex;
 use linked_list_allocator::Heap;
-
-#[cfg(feature = "oom-handler")]
-#[alloc_error_handler]
-fn oom(_: core::alloc::Layout) -> ! {
-    panic!("Allocation failed, out of memory");
-}
 
 pub struct EspHeap {
     heap: Mutex<RefCell<Heap>>,


### PR DESCRIPTION
Since the `alloc_error_handler` feature has now been stabilized, it has been removed from `nightly`. This is causing us issues in CI for other repos.

If users are using a recent `nightly` then this feature is not required. If they are using an older `nightly` for whatever reason, having to add their own `alloc_error_handler` is not asking much of the user.

@bjoernQ @MabezDev any objections?