### PR TITLE
Macros for more convenient usage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@
 
 #![no_std]
 
+pub mod macros;
+
 use core::{
     alloc::{GlobalAlloc, Layout},
     cell::RefCell,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,51 @@
+//! Macros provided for convenience
+
+/// Create a heap allocator providing a heap of the given size in bytes
+///
+/// You can only have ONE allocator at most
+#[macro_export]
+macro_rules! heap_allocator {
+    ($size:expr) => {
+        #[global_allocator]
+        static ALLOCATOR: $crate::EspHeap = $crate::EspHeap::empty();
+
+        fn init_heap() {
+            static mut HEAP: core::mem::MaybeUninit<[u8; $size]> = core::mem::MaybeUninit::uninit();
+
+            unsafe {
+                ALLOCATOR.init(HEAP.as_mut_ptr() as *mut u8, $size);
+            }
+        }
+
+        init_heap();
+    };
+}
+
+/// Create a heap allocator backed by PSRAM
+///
+/// You can only have ONE allocator at most. You need a SoC which supports PSRAM and activate the feature to enable it.
+/// You need to pass the PSRAM peripheral and the psram module path.
+///
+/// # Usage
+/// ```no_run
+/// esp_alloc::psram_allocator!(peripherals.PSRAM, hal::psram);
+/// ```
+#[macro_export]
+macro_rules! psram_allocator {
+    ($peripheral:expr,$psram_module:path) => {
+        #[global_allocator]
+        static ALLOCATOR: $crate::EspHeap = $crate::EspHeap::empty();
+
+        fn init_psram_heap() {
+            use $psram_module as _psram;
+            unsafe {
+                ALLOCATOR.init(_psram::psram_vaddr_start() as *mut u8, _psram::PSRAM_BYTES);
+            }
+        }
+        {
+            use $psram_module as _psram;
+            _psram::init_psram($peripheral);
+        }
+        init_psram_heap();
+    };
+}


### PR DESCRIPTION
This adds (totally optional) macros to setup the allocator for using PS-RAM or using a statically allocated memory region

Example

Without macro
```rust
#![no_std]
#![no_main]

extern crate alloc;
use core::mem::MaybeUninit;
use esp_backtrace as _;
use esp_println::println;
use hal::{clock::ClockControl, peripherals::Peripherals, prelude::*, Delay};

#[global_allocator]
static ALLOCATOR: esp_alloc::EspHeap = esp_alloc::EspHeap::empty();

fn init_heap() {
    const HEAP_SIZE: usize = 32 * 1024;
    static mut HEAP: MaybeUninit<[u8; HEAP_SIZE]> = MaybeUninit::uninit();

    unsafe {
        ALLOCATOR.init(HEAP.as_mut_ptr() as *mut u8, HEAP_SIZE);
    }
}
#[entry]
fn main() -> ! {
    init_heap();


              ...
```

With macro
```rust
#![no_std]
#![no_main]

extern crate alloc;
use esp_backtrace as _;
use esp_println::println;
use hal::prelude::*;

#[entry]
fn main() -> ! {
    esp_alloc::heap_allocator!(32*1024);

              ...
```

The macros don't do magical things - they just hide the annoying boilerplate code

Macros could be feature gated but I don't really see harm in not doing that