### PR TITLE
Add support for nightly allocator_api-feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ categories = [
     "no-std",
 ]
 
+[features]
+nightly = []
+
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"
 


### PR DESCRIPTION
I want to write an application using the `ESP32S3`'s LCD peripheral.
This peripheral works by allocating a framebuffer that contains the entire display content (For me: 800 x 480 pxl) and then streaming that out to the LCD using DMA.
For obvious reasons, this allocation has to be done in PSRAM, not in DRAM.

I haven't found a way to do that except for using `Vec::with_capacity_in` - which requires the nightly only `allocator_api`.

This PR implements support for this feature.
I also added some easy getting started documentation on the docs frontpage while I was at it.